### PR TITLE
Add pure-u-XY-0 rules for hiding elements at certain viewport sizes

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,19 @@ function pureGridsUnits(units, options) {
                     selectorPrefix: options.selectorPrefix + name + '-'
                 }));
 
+                // Add a rule which hides the element
+                mediaRules.push({
+                    type: 'rule',
+                    selectors: [
+                        options.selectorPrefix + name + '-0'
+                    ],
+                    declarations: [{
+                        type: 'declaration',
+                        property: 'display',
+                        value: 'none'
+                    }]
+                })
+
                 style.rules.push({
                     type : 'media',
                     media: mediaQueries[name],


### PR DESCRIPTION
.pure-u-sm-0, etc. Chose 0 instead of something else to keep the format consistent. As discussed here: https://github.com/yahoo/pure/issues/326